### PR TITLE
Use NGINX in the container to proxy requests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ FROM nginxinc/nginx-unprivileged:alpine AS runner
 
 USER 0:0
 
-RUN apk --no-cache add ca-certificates tzdata nodejs
+RUN apk --no-cache add ca-certificates tzdata nodejs tini
 
 WORKDIR /app
 ENV NODE_ENV=production
@@ -76,4 +76,5 @@ RUN mkdir /data/db
 
 EXPOSE 8081
 
+ENTRYPOINT ["/sbin/tini", "-g", "--"]
 CMD ["sh", "/start.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,9 @@ RUN npm run build
 
 
 # Final image
-FROM alpine:latest AS runner
+FROM nginxinc/nginx-unprivileged:alpine AS runner
+
+USER 0:0
 
 RUN apk --no-cache add ca-certificates tzdata nodejs
 
@@ -65,11 +67,13 @@ RUN chown 1000:1000 /data
 COPY start.sh /start.sh
 RUN chmod +x /start.sh
 
+COPY nginx/default.conf /etc/nginx/conf.d/default.conf
+RUN chown 1000:1000 /etc/nginx/conf.d/default.conf
+
 USER 1000:1000
 RUN mkdir /data/surveys
 RUN mkdir /data/db
 
-EXPOSE 3000
-EXPOSE 8080
+EXPOSE 8081
 
 CMD ["sh", "/start.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,7 @@ RUN apk --no-cache add ca-certificates tzdata nodejs tini
 
 WORKDIR /app
 ENV NODE_ENV=production
+ENV CONSOLE_API_ADDR_INTERNAL=http://127.0.0.1:8080
 
 COPY --from=ui_builder /app/public ./public
 

--- a/compose-combined.yml
+++ b/compose-combined.yml
@@ -8,8 +8,7 @@ services:
         api: ./api
         ui: ./ui
     ports:
-      - "3000:3000"
-      - "8080:8080"
+      - "8081:8081"
     init: true
     environment:
       - LOG_LEVEL=debug
@@ -17,7 +16,7 @@ services:
       - DATABASE_URL=/data/sqlite3/formulosity.db
       - SURVEYS_DIR=/data/surveys
       - CONSOLE_API_ADDR_INTERNAL=http://127.0.0.1:8080
-      - CONSOLE_API_ADDR=http://127.0.0.1:8080
+      - CONSOLE_API_ADDR=http://192.168.11.101:8081/api
       - IRON_SESSION_SECRET=e75af92dffba8065f2730472f45f2046941fe35f361739d31992f42d88d6bf6c
       - HTTP_BASIC_AUTH=user:pass
     volumes:

--- a/compose-combined.yml
+++ b/compose-combined.yml
@@ -15,7 +15,6 @@ services:
       - DATABASE_TYPE=sqlite # postgres|sqlite
       - DATABASE_URL=/data/sqlite3/formulosity.db
       - SURVEYS_DIR=/data/surveys
-      - CONSOLE_API_ADDR_INTERNAL=http://127.0.0.1:8080
       - CONSOLE_API_ADDR=http://192.168.11.101:8081/api
       - IRON_SESSION_SECRET=e75af92dffba8065f2730472f45f2046941fe35f361739d31992f42d88d6bf6c
       - HTTP_BASIC_AUTH=user:pass

--- a/compose-combined.yml
+++ b/compose-combined.yml
@@ -15,7 +15,7 @@ services:
       - DATABASE_TYPE=sqlite # postgres|sqlite
       - DATABASE_URL=/data/sqlite3/formulosity.db
       - SURVEYS_DIR=/data/surveys
-      - CONSOLE_API_ADDR=http://192.168.11.101:8081/api
+      - CONSOLE_API_ADDR=http://127.0.0.1:8081/api
       - IRON_SESSION_SECRET=e75af92dffba8065f2730472f45f2046941fe35f361739d31992f42d88d6bf6c
       - HTTP_BASIC_AUTH=user:pass
     volumes:

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,0 +1,22 @@
+server {
+    listen       8081;
+
+    location / {
+        proxy_pass http://<HOSTNAME>:3000;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /api {
+        rewrite ^/api/(.*) /$1  break;
+        proxy_pass http://127.0.0.1:8080;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+
+}

--- a/start.sh
+++ b/start.sh
@@ -1,3 +1,8 @@
+# Fix Nginx config
+sed "s/<HOSTNAME>/$HOSTNAME/g" /etc/nginx/conf.d/default.conf > /var/tmp/default.conf
+cat /var/tmp/default.conf > /etc/nginx/conf.d/default.conf
+
+nginx
 /api/api &
 node /app/server.js &
 wait -n


### PR DESCRIPTION
Hi,

I have based the container on a nonroot NGINX container that listens on port 8081
Requests to / are proxied to the frontend running on 3000
Requests to /api are proxied to the backend on port 8080

Some things are still a bit bodged and can be improved:  
1. Make Node app listen on 127.0.0.1  
  when the Node app starts up it prints this for me:
  `formulosity-1  |    - Local:        http://f9361d85ded3:3000`
  `formulosity-1  |    - Network:      http://172.21.1.2:3000`
  It is actually not listening on 127.0.0.1 or localhost, only on the IP of the docker container or the random hostname of the container. 
  I could not figure out how to make it listen on localhost. This leads to some complication with the nginx config file where I have to replace some text after the container starts up.
  This could all be removed if the Node app would listen on 127.0.0.1.
  The server.js file includes this line `const hostname = process.env.HOSTNAME || '0.0.0.0'` but is automatically generated and I don't know how to change it at build time.
  The API listens on 127.0.0.1

2. Don't use `CONSOLE_API_ADDR=http://127.0.0.1:8081/api`:
  For the combined image with NGINX this is basically always the URL that is typed into the browser + `/api` so if the app could somehow check if this ENV Variable exists and  
if yes -> use it  
if no -> just add `/api` to the current base url  
then this variable can be removed from the compose file
3. Minor: Change the port of the backend API
  Nginx rootless canonically listens on 8080 but this port is taken up by the backend.
If the backend port can be changed (backend port doesn't matter because it is not exposed to the outside) nginx could use the "standard port"