### PR TITLE
Mysql storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 api/pkg/github/tmp/
 api/pkg/parser/tmp/
 api/postgres-data/
+api/mysql-data/
 api/sqlite3/
 api/uploads/
 ui/node_modules

--- a/README.md
+++ b/README.md
@@ -309,8 +309,8 @@ The demo service (links above) is deployed to Fly.io (Go, SQLite) and Vercel (Ne
 
 API:
 
-- `DATABASE_TYPE` - `sqlite` or `postgres`
-- `DATABASE_URL` - Postgres or SQLite connection string
+- `DATABASE_TYPE` - `postgres`, `mysql`, or `sqlite`
+- `DATABASE_URL` - Postgres, Mysql or SQLite connection string
 - `LOG_LEVEL` - Log level, e.g. `info`
 - `SURVEYS_DIR` - Directory with surveys, e.g. `/root/surveys`. It's suggested to use mounted volume for this directory.
 

--- a/api/go.mod
+++ b/api/go.mod
@@ -17,9 +17,11 @@ require (
 )
 
 require (
+	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/go-sql-driver/mysql v1.8.1 // indirect
 	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
 	github.com/gorilla/css v1.0.1 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect

--- a/api/go.sum
+++ b/api/go.sum
@@ -1,3 +1,5 @@
+filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
+filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 h1:L/gRVlceqvL25UVaW/CKtUDjefjrs0SPonmDGUVOYP0=
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
@@ -24,6 +26,8 @@ github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nos
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/go-ozzo/ozzo-validation/v4 v4.3.0 h1:byhDUpfEwjsVQb1vBunvIjh2BHQ9ead57VkAEY4V+Es=
 github.com/go-ozzo/ozzo-validation/v4 v4.3.0/go.mod h1:2NKgrcHl3z6cJs+3Oo940FPRiTzuqKbvfrL2RxCj6Ew=
+github.com/go-sql-driver/mysql v1.8.1 h1:LedoTUt/eveggdHS9qUFC1EFSa8bU2+1pZjSRpvNJ1Y=
+github.com/go-sql-driver/mysql v1.8.1/go.mod h1:wEBSXgmK//2ZFJyE+qWnIsVGmvmEKlqwuVSjsCm7DZg=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=

--- a/api/migrations/mysql/000001_schema.up.sql
+++ b/api/migrations/mysql/000001_schema.up.sql
@@ -1,0 +1,12 @@
+CREATE TABLE
+    `surveys` (
+        `id` INTEGER PRIMARY KEY AUTO_INCREMENT,
+        `uuid` VARCHAR(36) NOT NULL UNIQUE DEFAULT (UUID()),
+        `created_at` DATETIME(3) DEFAULT CURRENT_TIMESTAMP(3),
+        `parse_status` VARCHAR(255),
+        `delivery_status` TEXT,
+        `error_log` TEXT,
+        `name` VARCHAR(255) NOT NULL UNIQUE,
+        `url_slug` VARCHAR(255) NOT NULL UNIQUE,
+        `config` TEXT
+    );

--- a/api/migrations/mysql/000002_schema.up.sql
+++ b/api/migrations/mysql/000002_schema.up.sql
@@ -1,0 +1,11 @@
+CREATE TABLE
+    `surveys_sessions` (
+        `id` INTEGER PRIMARY KEY AUTO_INCREMENT,
+        `uuid` VARCHAR(36) NOT NULL UNIQUE DEFAULT (UUID()),
+        `created_at` DATETIME(3) DEFAULT CURRENT_TIMESTAMP(3),
+        `completed_at` DATETIME(3),
+        `status` VARCHAR(255),
+        `survey_id` INTEGER NOT NULL,
+        `ip_addr` TEXT,
+        FOREIGN KEY (`survey_id`) REFERENCES `surveys` (`id`) ON DELETE CASCADE
+    );

--- a/api/migrations/mysql/000003_schema.up.sql
+++ b/api/migrations/mysql/000003_schema.up.sql
@@ -1,0 +1,8 @@
+CREATE TABLE
+    `surveys_questions` (
+        `id` INTEGER PRIMARY KEY AUTO_INCREMENT,
+        `uuid` VARCHAR(36) NOT NULL UNIQUE DEFAULT (UUID()),
+        `survey_id` INTEGER NOT NULL,
+        `question_id` VARCHAR(255) NOT NULL,
+        FOREIGN KEY (`survey_id`) REFERENCES `surveys` (`id`) ON DELETE CASCADE
+    );

--- a/api/migrations/mysql/000004_schema.up.sql
+++ b/api/migrations/mysql/000004_schema.up.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX `surveys_questions_id` ON `surveys_questions` (`survey_id`, `question_id`);

--- a/api/migrations/mysql/000005_schema.up.sql
+++ b/api/migrations/mysql/000005_schema.up.sql
@@ -1,0 +1,11 @@
+CREATE TABLE
+    `surveys_answers` (
+        `id` INTEGER PRIMARY KEY AUTO_INCREMENT,
+        `uuid` VARCHAR(36) NOT NULL UNIQUE DEFAULT (UUID()),
+        `created_at` DATETIME(3) DEFAULT CURRENT_TIMESTAMP(3),
+        `session_id` INTEGER NOT NULL,
+        `question_id` INTEGER NOT NULL,
+        `answer` TEXT,
+        FOREIGN KEY (`session_id`) REFERENCES surveys_sessions (`id`) ON DELETE CASCADE,
+        FOREIGN KEY (`question_id`) REFERENCES surveys_questions (`id`) ON DELETE CASCADE
+    );

--- a/api/migrations/mysql/000006_schema.up.sql
+++ b/api/migrations/mysql/000006_schema.up.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX `surveys_answers_unique` ON `surveys_answers` (`session_id`, `question_id`);

--- a/api/pkg/services/services.go
+++ b/api/pkg/services/services.go
@@ -8,8 +8,8 @@ import (
 )
 
 type Services struct {
-	Storage       storage.Interface
-	FileStorage   storage.FileInterface
+	Storage     storage.Interface
+	FileStorage storage.FileInterface
 }
 
 func InitServices() (Services, error) {
@@ -19,12 +19,14 @@ func InitServices() (Services, error) {
 		svc.Storage = new(storage.Postgres)
 	case "sqlite":
 		svc.Storage = new(storage.Sqlite)
+	case "mysql":
+		svc.Storage = new(storage.Mysql)
 	default:
-		return svc, fmt.Errorf("unknown database type")
+		return svc, fmt.Errorf("unknown database type: %s", os.Getenv("DATABASE_TYPE"))
 	}
 
 	if err := svc.Storage.Init(); err != nil {
-		return svc, fmt.Errorf("unable to init db %w", err)
+		return svc, fmt.Errorf("unable to init db - %w", err)
 	}
 
 	svc.FileStorage = new(storage.File)

--- a/api/pkg/storage/mysql.go
+++ b/api/pkg/storage/mysql.go
@@ -1,0 +1,425 @@
+package storage
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/golang-migrate/migrate/v4"
+	migrateMysql "github.com/golang-migrate/migrate/v4/database/mysql"
+	_ "github.com/golang-migrate/migrate/v4/source/file"
+	"github.com/plutov/formulosity/api/pkg/types"
+)
+
+type Mysql struct {
+	conn *sql.DB
+	addr string
+}
+
+func (m *Mysql) Init() error {
+	m.addr = os.Getenv("DATABASE_URL")
+	if len(m.addr) == 0 {
+		return errors.New("DATABASE_URL env var is empty")
+	}
+
+	var err error
+	m.conn, err = sql.Open("mysql", m.addr)
+	if err != nil {
+		return err
+	}
+
+	if err = m.Ping(); err != nil {
+		return err
+	}
+
+	return m.Migrate()
+}
+
+func (m *Mysql) Ping() error {
+	return m.conn.Ping()
+}
+
+func (m *Mysql) Close() error {
+	return m.conn.Close()
+}
+
+func (m *Mysql) Migrate() error {
+	migrationsDir := "file://migrations/mysql"
+
+	driver, err := migrateMysql.WithInstance(m.conn, &migrateMysql.Config{
+		MigrationsTable: "schema_migrations",
+	})
+	if err != nil {
+		return fmt.Errorf("error creating migration driver: %w", err)
+	}
+
+	mig, err := migrate.NewWithDatabaseInstance(migrationsDir, "mysql", driver)
+	if err != nil {
+		return fmt.Errorf("failed to create migration instance: %w", err)
+	}
+
+	err = mig.Up()
+	if err != nil {
+		if err != migrate.ErrNoChange {
+			return fmt.Errorf("failed to run migrations: %w", err)
+		}
+	}
+	return nil
+}
+
+func (m *Mysql) CreateSurvey(survey *types.Survey) error {
+	insert := `INSERT INTO surveys
+		(parse_status, delivery_status, error_log, name, config, url_slug)
+		VALUES (?, ?, ?, ?, ?, ?);`
+
+	_, err := m.conn.Exec(insert, survey.ParseStatus, survey.DeliveryStatus, survey.ErrorLog, survey.Name, survey.Config, survey.URLSlug)
+	if err != nil {
+		return fmt.Errorf("unable to create survey - %w", err)
+	}
+
+	row := m.conn.QueryRow(`SELECT id FROM surveys WHERE id = LAST_INSERT_ID();`)
+	return row.Scan(&survey.ID)
+}
+
+func (m *Mysql) UpdateSurvey(survey *types.Survey) error {
+	query := `UPDATE surveys
+		SET parse_status=?, delivery_status=?, error_log=?, name=?, config=?, url_slug=?
+		WHERE uuid=?;`
+
+	_, err := m.conn.Exec(query, survey.ParseStatus, survey.DeliveryStatus, survey.ErrorLog, survey.Name, survey.Config, survey.URLSlug, survey.UUID)
+	return err
+}
+
+func (m *Mysql) GetSurveys() ([]*types.Survey, error) {
+	query := `SELECT
+		s.id, s.uuid, s.created_at,
+		s.parse_status, s.delivery_status,
+		s.error_log, s.name, s.config, s.url_slug,
+		(SELECT COUNT(*) FROM surveys_sessions WHERE survey_id = s.id AND status = ?) AS sessions_count_in_progress,
+		(SELECT COUNT(*) FROM surveys_sessions WHERE survey_id = s.id AND status = ?) AS sessions_count_completed
+	FROM surveys AS s;`
+
+	rows, err := m.conn.Query(query, types.SurveySessionStatus_InProgress, types.SurveySessionStatus_Completed)
+	if err != nil {
+		return nil, err
+	}
+
+	surveys := []*types.Survey{}
+	for rows.Next() {
+		survey := &types.Survey{}
+
+		err := rows.Scan(&survey.ID, &survey.UUID, &survey.CreatedAt,
+			&survey.ParseStatus, &survey.DeliveryStatus, &survey.ErrorLog,
+			&survey.Name, &survey.Config, &survey.URLSlug,
+			&survey.Stats.SessionsCountInProgess, &survey.Stats.SessionsCountCompleted)
+		if err != nil {
+			return nil, err
+		}
+
+		totalResponses := survey.Stats.SessionsCountInProgess + survey.Stats.SessionsCountCompleted
+		if totalResponses > 0 {
+			survey.Stats.CompletionRate = (survey.Stats.SessionsCountCompleted * 100) / totalResponses
+		}
+
+		surveys = append(surveys, survey)
+	}
+
+	return surveys, nil
+}
+
+func (m *Mysql) GetSurveyByField(field string, value interface{}) (*types.Survey, error) {
+	query := fmt.Sprintf(`SELECT
+		s.id, s.uuid, s.created_at,
+		s.parse_status, s.delivery_status,
+		s.error_log, s.name, s.config, s.url_slug
+	FROM surveys AS s
+	WHERE s.%s=?;`, field)
+
+	row := m.conn.QueryRow(query, value)
+	survey := &types.Survey{}
+	err := row.Scan(&survey.ID, &survey.UUID, &survey.CreatedAt,
+		&survey.ParseStatus, &survey.DeliveryStatus, &survey.ErrorLog,
+		&survey.Name, &survey.Config, &survey.URLSlug)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+
+		return nil, err
+	}
+
+	return survey, nil
+}
+
+func (m *Mysql) UpsertSurveyQuestions(survey *types.Survey) error {
+	if survey == nil || survey.Config == nil || survey.Config.Questions == nil {
+		return nil
+	}
+
+	placeholders := []string{}
+	values := []interface{}{}
+	values = append(values, survey.ID)
+	for i := range survey.Config.Questions.Questions {
+		placeholders = append(placeholders, "?")
+		values = append(values, survey.Config.Questions.Questions[i].ID)
+	}
+	// Delete removed questions
+	deleteQuery := `DELETE FROM surveys_questions
+	WHERE survey_id = ?
+	AND question_id NOT IN (` + strings.Join(placeholders, ", ") + `);`
+
+	_, err := m.conn.Exec(deleteQuery, values...)
+	if err != nil {
+		return err
+	}
+
+	placeholders = []string{}
+	values = []interface{}{}
+	for _, q := range survey.Config.Questions.Questions {
+		placeholders = append(placeholders, "(?, ?)")
+		values = append(values, survey.ID, q.ID)
+	}
+
+	insertQuery := `INSERT INTO surveys_questions
+		(survey_id, question_id)
+		VALUES ` + strings.Join(placeholders, ", ") +
+		` ON DUPLICATE KEY UPDATE id=id;`
+
+	_, err = m.conn.Exec(insertQuery, values...)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *Mysql) GetSurveyQuestions(surveyID int64) ([]types.Question, error) {
+	query := `SELECT
+		uuid, question_id
+	FROM surveys_questions
+	WHERE survey_id=?;`
+
+	rows, err := m.conn.Query(query, surveyID)
+	if err != nil {
+		return []types.Question{}, err
+	}
+
+	questions := []types.Question{}
+	for rows.Next() {
+		question := types.Question{}
+
+		err := rows.Scan(&question.UUID, &question.ID)
+		if err != nil {
+			return []types.Question{}, err
+		}
+
+		questions = append(questions, question)
+	}
+
+	return questions, nil
+}
+
+func (m *Mysql) CreateSurveySession(session *types.SurveySession) error {
+	insertQuery := `INSERT INTO surveys_sessions
+		(status, survey_id, ip_addr)
+		VALUES (?, (SELECT id FROM surveys WHERE uuid = ?), ?);`
+
+	_, err := m.conn.Exec(insertQuery, session.Status, session.SurveyUUID, session.IPAddr)
+	if err != nil {
+		return fmt.Errorf("unable to create survey session")
+	}
+
+	query := `SELECT id, uuid
+		FROM surveys_sessions
+		WHERE id = LAST_INSERT_ID();`
+
+	row, err := m.conn.Query(query)
+	if err != nil {
+		return fmt.Errorf("unable to retrieve survey session")
+	}
+	return row.Scan(&session.ID, &session.UUID)
+}
+
+func (m *Mysql) UpdateSurveySessionStatus(sessionUUID string, newStatus types.SurveySessionStatus) error {
+	completedAt := "NULL"
+	if newStatus == types.SurveySessionStatus_Completed {
+		completedAt = "NOW()"
+	}
+
+	query := fmt.Sprintf(`UPDATE surveys_sessions
+		SET status = ?, completed_at = %s
+		WHERE uuid = ?;`, completedAt)
+
+	_, err := m.conn.Exec(query, newStatus, sessionUUID)
+
+	return err
+}
+
+func (m *Mysql) GetSurveySession(surveyUUID string, sessionUUID string) (*types.SurveySession, error) {
+	query := `SELECT
+		ss.id, ss.uuid, ss.created_at, ss.status, s.uuid
+	FROM surveys_sessions AS ss
+	INNER JOIN surveys AS s ON s.id = ss.survey_id
+	WHERE ss.uuid=? AND s.uuid=?;`
+
+	row := m.conn.QueryRow(query, sessionUUID, surveyUUID)
+	session := &types.SurveySession{}
+	err := row.Scan(&session.ID, &session.UUID, &session.CreatedAt, &session.Status, &session.SurveyUUID)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+
+		return nil, err
+	}
+
+	return session, nil
+}
+
+func (m *Mysql) GetSurveySessionByIPAddress(surveyUUID string, ipAddr string) (*types.SurveySession, error) {
+	query := `SELECT
+		ss.id, ss.uuid, ss.created_at, ss.status, s.uuid
+	FROM surveys_sessions AS ss
+	INNER JOIN surveys AS s ON s.id = ss.survey_id
+	WHERE s.uuid=? AND ss.ip_addr=?;`
+
+	row := m.conn.QueryRow(query, surveyUUID, ipAddr)
+	session := &types.SurveySession{}
+	err := row.Scan(&session.ID, &session.UUID, &session.CreatedAt, &session.Status, &session.SurveyUUID)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+
+		return nil, err
+	}
+
+	return session, nil
+
+}
+
+func (m *Mysql) GetSurveySessionAnswers(sessionUUID string) ([]types.QuestionAnswer, error) {
+	query := `SELECT
+		q.id, q.uuid, sa.answer
+	FROM surveys_answers AS sa
+	LEFT JOIN surveys_questions AS q ON q.id = sa.question_id
+	WHERE session_id IN (SELECT id FROM surveys_sessions WHERE uuid = ?);`
+
+	rows, err := m.conn.Query(query, sessionUUID)
+	if err != nil {
+		return nil, err
+	}
+
+	answers := []types.QuestionAnswer{}
+	for rows.Next() {
+		answer := types.QuestionAnswer{}
+
+		err := rows.Scan(&answer.QuestionID, &answer.QuestionUUID, &answer.AnswerBytes)
+		if err != nil {
+			return nil, err
+		}
+
+		answers = append(answers, answer)
+	}
+
+	return answers, nil
+}
+
+func (m *Mysql) UpsertSurveyQuestionAnswer(sessionUUID string, questionUUID string, answer types.Answer) error {
+	query := `INSERT INTO surveys_answers
+		(session_id, question_id, answer)
+		VALUES (
+			(SELECT id FROM surveys_sessions WHERE uuid = ?),
+			(SELECT id FROM surveys_questions WHERE uuid = ?),
+			?
+		)
+		ON DUPLICATE KEY
+		UPDATE answer = ?;`
+
+	_, err := m.conn.Exec(query, sessionUUID, questionUUID, answer, answer)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *Mysql) GetSurveySessionsWithAnswers(surveyUUID string, filter *types.SurveySessionsFilter) ([]types.SurveySession, int, error) {
+	query := fmt.Sprintf(`
+	SELECT
+		ss.id, ss.uuid, ss.created_at, ss.completed_at, ss.status, q.id, q.uuid, sa.answer
+	FROM (
+		SELECT * from surveys_sessions
+		ORDER BY %s %s
+		LIMIT %d OFFSET %d
+	) AS ss
+	INNER JOIN surveys AS s ON s.id = ss.survey_id
+	LEFT JOIN surveys_answers AS sa ON sa.session_id = ss.id
+	LEFT JOIN surveys_questions AS q ON q.id = sa.question_id
+	WHERE s.uuid=?
+	ORDER BY ss.%s %s
+	;`, filter.SortBy, filter.Order, filter.Limit, filter.Offset, filter.SortBy, filter.Order)
+
+	rows, err := m.conn.Query(query, surveyUUID)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	sessions := []types.SurveySession{}
+	sessionsMap := map[string]types.SurveySession{}
+	for rows.Next() {
+		session := types.SurveySession{}
+		answer := types.QuestionAnswer{}
+		var (
+			questionID   sql.NullString
+			questionUUID sql.NullString
+		)
+
+		err := rows.Scan(&session.ID, &session.UUID, &session.CreatedAt, &session.CompletedAt, &session.Status, &questionID, &questionUUID, &answer.AnswerBytes)
+		if err != nil {
+			return nil, 0, err
+		}
+
+		if _, ok := sessionsMap[session.UUID]; !ok {
+			session.QuestionAnswers = []types.QuestionAnswer{}
+			sessionsMap[session.UUID] = session
+			sessions = append(sessions, session)
+		}
+
+		if questionID.Valid && questionUUID.Valid {
+			answer.QuestionID = questionID.String
+			answer.QuestionUUID = questionUUID.String
+
+			sessionCopy := sessionsMap[session.UUID]
+			sessionCopy.QuestionAnswers = append(sessionCopy.QuestionAnswers, answer)
+			sessionsMap[session.UUID] = sessionCopy
+		}
+	}
+
+	totalCount, err := m.getSurveySessionsCount(surveyUUID)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	for i, session := range sessions {
+		fullSession := sessionsMap[session.UUID]
+		sessions[i].QuestionAnswers = fullSession.QuestionAnswers
+	}
+
+	return sessions, totalCount, nil
+}
+
+func (m *Mysql) getSurveySessionsCount(surveyUUID string) (int, error) {
+	query := `SELECT
+		COUNT(*)
+	FROM surveys_sessions AS ss
+	INNER JOIN surveys AS s ON s.id = ss.survey_id
+	WHERE s.uuid=?;`
+
+	row := m.conn.QueryRow(query, surveyUUID)
+	var count int
+	err := row.Scan(&count)
+	return count, err
+}

--- a/compose.yaml
+++ b/compose.yaml
@@ -5,18 +5,20 @@ services:
       context: ./api
     ports:
       - "9900:8080"
-    # depends_on:
-    # - postgres
+    depends_on:
+      mysql:
+        condition: service_healthy
     environment:
       - LOG_LEVEL=debug
-      - DATABASE_TYPE=sqlite # postgres|sqlite
+      - DATABASE_TYPE=mysql # postgres|sqlite|mysql
       # - DATABASE_URL=postgres://postgres:postgres@postgres:5432/formulosity?sslmode=disable
-      - DATABASE_URL=/root/sqlite3/formulosity.db
+      # - DATABASE_URL=/root/sqlite3/formulosity.db
+      - DATABASE_URL=user:pass@tcp(mysql:3306)/formulosity?charset=utf8mb4&parseTime=True&loc=Local
       - SURVEYS_DIR=/root/surveys
       - UPLOADS_DIR=/root/uploads
     volumes:
       - ./api/surveys:/root/surveys
-      - ./api/sqlite3:/root/sqlite3
+      # - ./api/sqlite3:/root/sqlite3
       - ./api/uploads:/root/uploads
 
   ui:
@@ -46,6 +48,27 @@ services:
   #     - ./api/postgres-data:/var/lib/postgresql/data
   #   logging:
   #     driver: none
+
+  mysql:
+    image: mysql:8
+    restart: always
+    environment:
+      - MYSQL_USER=user
+      - MYSQL_PASSWORD=pass
+      - MYSQL_DATABASE=formulosity
+      - MYSQL_RANDOM_ROOT_PASSWORD=true
+    ports:
+      - "3306:3306"
+    volumes:
+      - ./api/mysql-data:/var/lib/mysql
+    logging:
+      driver: none
+    healthcheck:
+      test: ["CMD", "mysqladmin" ,"ping", "-h", "localhost"]
+      start_interval: 10s
+      start_period: 40s
+      timeout: 20s
+      retries: 10
 
 volumes:
   dbvolume:


### PR DESCRIPTION
https://github.com/plutov/formulosity/issues/29

For a hacktoberfest contribution, I have implemented mysql storage. It was a bit tricky to work past mysql limitations, but now all the tests are passing. This pull request introduces support for MySQL alongside existing support for PostgreSQL and SQLite. The changes span configuration updates, new database migrations, and modifications to the service initialization logic.

### Database Support Expansion:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L312-R313): Updated `DATABASE_TYPE` to include `mysql` and revised the description for `DATABASE_URL` to include MySQL connection strings.
* [`api/go.mod`](diffhunk://#diff-ba0784a950902285760f839a4ad720a381b2981e8a67147f5f43f7508e6343edR20-R24): Added `github.com/go-sql-driver/mysql` and `filippo.io/edwards25519` as indirect dependencies.

### MySQL Migrations:

* [`api/migrations/mysql/000001_schema.up.sql`](diffhunk://#diff-0f4c7f2ca3d944e53895b850569367ec5112dfec7a1570c206100a830322f5afR1-R12): Created `surveys` table with columns for survey metadata.
* [`api/migrations/mysql/000002_schema.up.sql`](diffhunk://#diff-8683875afdb4d954eb79bdac4873b0417670e0dde9664880a7b6215f05fc5e23R1-R11): Created `surveys_sessions` table with columns for session data and a foreign key reference to `surveys`.
* [`api/migrations/mysql/000003_schema.up.sql`](diffhunk://#diff-ff813a88454d2e2e10e51fc1bc7c9e783ddfa7fe103f53527989ba91ce05081dR1-R8): Created `surveys_questions` table with columns for question data and a foreign key reference to `surveys`.
* [`api/migrations/mysql/000004_schema.up.sql`](diffhunk://#diff-e97de197ff678df9bf4fe714e1cbf2e8b72f395951426ade0fb47bdc4a66f34fR1): Added a unique index on `surveys_questions` for `survey_id` and `question_id`.
* [`api/migrations/mysql/000005_schema.up.sql`](diffhunk://#diff-d2e00294b28e432591cd1c2bf6004c80ed0ad28b7a821cd2ea19f94a7fc28f17R1-R11): Created `surveys_answers` table with columns for answer data and foreign key references to `surveys_sessions` and `surveys_questions`.
* [`api/migrations/mysql/000006_schema.up.sql`](diffhunk://#diff-5963e1d2de9dcf632abc22b50063af7393869079b24f51da2dd44abb6815122bR1): Added a unique index on `surveys_answers` for `session_id` and `question_id`.

### Service Initialization:

* [`api/pkg/services/services.go`](diffhunk://#diff-7833067c03f2e8900ee396a25bd19b481b4f51bd66f1e48121a590d28000104dR22-R29): Added support for initializing a MySQL storage backend based on the `DATABASE_TYPE` environment variable.

### Docker Configuration:

* [`compose.yaml`](diffhunk://#diff-facaded51b7d1c9656ae43b449b69aa398fee9129321a0001d97048c00c8cc1cL8-R21): Updated the `api` service to depend on MySQL and added configuration for a MySQL service with health checks and volume mappings. [[1]](diffhunk://#diff-facaded51b7d1c9656ae43b449b69aa398fee9129321a0001d97048c00c8cc1cL8-R21) [[2]](diffhunk://#diff-facaded51b7d1c9656ae43b449b69aa398fee9129321a0001d97048c00c8cc1cR52-R72)

Some known issues:
1. The docker-compose file is getting a bit messy now. End users are expected to fill in their data, and comment out various lines corresponding to databases they don't use. It might be nice to have multiple sample docker-compose files, one for each database service type.
2. Mysql does not appear to support multiStatement migrations (multiple DDL in a single file). The workaround I have seen (and used here) is to have a single statement per file, so there are six schema.up.sql files rather than a single one.